### PR TITLE
Use ore deposit rules for commodity classification

### DIFF
--- a/Rule1_OreDeposit.json
+++ b/Rule1_OreDeposit.json
@@ -1,0 +1,214 @@
+{
+  "rules": [
+    {
+      "Major_category": "Precious metals",
+      "Minor_category": "Gold",
+      "Commodities_elements": ["Gold"],
+      "Commodities_combined": ["Gold"],
+      "aliases": ["gold", "auriferous", "orogenic gold", "lode gold"]
+    },
+    {
+      "Major_category": "Precious metals",
+      "Minor_category": "Silver",
+      "Commodities_elements": ["Silver"],
+      "Commodities_combined": ["Silver"],
+      "aliases": ["silver", "argentiferous"]
+    },
+    {
+      "Major_category": "Precious metals",
+      "Minor_category": "Platinum-group elements",
+      "Commodities_elements": ["Platinum", "Palladium", "Rhodium"],
+      "Commodities_combined": ["PGE", "PGM"],
+      "aliases": ["platinum", "palladium", "rhodium", "platinum group", "pge", "pgm"]
+    },
+    {
+      "Major_category": "Base metals",
+      "Minor_category": "Copper",
+      "Commodities_elements": ["Copper"],
+      "Commodities_combined": ["Copper"],
+      "aliases": ["copper", "chalcopyrite", "cu"]
+    },
+    {
+      "Major_category": "Base metals",
+      "Minor_category": "Lead",
+      "Commodities_elements": ["Lead"],
+      "Commodities_combined": ["Lead"],
+      "aliases": ["lead", "galena", "pb"]
+    },
+    {
+      "Major_category": "Base metals",
+      "Minor_category": "Zinc",
+      "Commodities_elements": ["Zinc"],
+      "Commodities_combined": ["Zinc"],
+      "aliases": ["zinc", "sphalerite", "zn"]
+    },
+    {
+      "Major_category": "Base metals",
+      "Minor_category": "Nickel",
+      "Commodities_elements": ["Nickel"],
+      "Commodities_combined": ["Nickel"],
+      "aliases": ["nickel", "ni"]
+    },
+    {
+      "Major_category": "Base metals",
+      "Minor_category": "Tin",
+      "Commodities_elements": ["Tin"],
+      "Commodities_combined": ["Tin"],
+      "aliases": ["tin", "cassiterite", "sn"]
+    },
+    {
+      "Major_category": "Base metals",
+      "Minor_category": "Molybdenum",
+      "Commodities_elements": ["Molybdenum"],
+      "Commodities_combined": ["Molybdenum"],
+      "aliases": ["molybdenum", "moly", "mo"]
+    },
+    {
+      "Major_category": "Base metals",
+      "Minor_category": "Copper-Gold polymetallic",
+      "Commodities_elements": ["Copper", "Gold"],
+      "Commodities_combined": ["Cu-Au"],
+      "aliases": ["cu-au", "copper-gold", "cu au", "au-cu"]
+    },
+    {
+      "Major_category": "Battery minerals",
+      "Minor_category": "Lithium",
+      "Commodities_elements": ["Lithium"],
+      "Commodities_combined": ["Lithium"],
+      "aliases": ["lithium", "li", "spodumene", "lct pegmatite"]
+    },
+    {
+      "Major_category": "Battery minerals",
+      "Minor_category": "Cobalt",
+      "Commodities_elements": ["Cobalt"],
+      "Commodities_combined": ["Cobalt"],
+      "aliases": ["cobalt", "co"]
+    },
+    {
+      "Major_category": "Battery minerals",
+      "Minor_category": "Graphite",
+      "Commodities_elements": ["Graphite"],
+      "Commodities_combined": ["Graphite"],
+      "aliases": ["graphite", "graphitic", "graphene"]
+    },
+    {
+      "Major_category": "Battery minerals",
+      "Minor_category": "Manganese",
+      "Commodities_elements": ["Manganese"],
+      "Commodities_combined": ["Manganese"],
+      "aliases": ["manganese", "mn"]
+    },
+    {
+      "Major_category": "Battery minerals",
+      "Minor_category": "Vanadium",
+      "Commodities_elements": ["Vanadium"],
+      "Commodities_combined": ["Vanadium"],
+      "aliases": ["vanadium", "v2o5", "vanadiferous", "v"]
+    },
+    {
+      "Major_category": "Bulk commodities",
+      "Minor_category": "Iron ore",
+      "Commodities_elements": ["Iron"],
+      "Commodities_combined": ["Iron ore"],
+      "aliases": ["iron ore", "banded iron", "hematite", "magnetite", "fe"]
+    },
+    {
+      "Major_category": "Bulk commodities",
+      "Minor_category": "Bauxite",
+      "Commodities_elements": ["Bauxite"],
+      "Commodities_combined": ["Bauxite"],
+      "aliases": ["bauxite", "aluminum ore", "laterite", "al"]
+    },
+    {
+      "Major_category": "Bulk commodities",
+      "Minor_category": "Coal",
+      "Commodities_elements": ["Coal"],
+      "Commodities_combined": ["Coal"],
+      "aliases": ["coal", "coking coal", "thermal coal"]
+    },
+    {
+      "Major_category": "Bulk commodities",
+      "Minor_category": "Phosphate",
+      "Commodities_elements": ["Phosphate"],
+      "Commodities_combined": ["Phosphate"],
+      "aliases": ["phosphate", "phosphorite", "apatite"]
+    },
+    {
+      "Major_category": "Energy minerals",
+      "Minor_category": "Uranium",
+      "Commodities_elements": ["Uranium"],
+      "Commodities_combined": ["Uranium"],
+      "aliases": ["uranium", "uraninite", "u3o8", "u-oxide"]
+    },
+    {
+      "Major_category": "Energy minerals",
+      "Minor_category": "Thorium",
+      "Commodities_elements": ["Thorium"],
+      "Commodities_combined": ["Thorium"],
+      "aliases": ["thorium", "th"]
+    },
+    {
+      "Major_category": "Critical minerals",
+      "Minor_category": "Rare earth elements",
+      "Commodities_elements": ["Rare earth elements"],
+      "Commodities_combined": ["REE"],
+      "aliases": ["rare earth", "rare-earth", "ree", "rare earth element", "rare earths"]
+    },
+    {
+      "Major_category": "Critical minerals",
+      "Minor_category": "Niobium",
+      "Commodities_elements": ["Niobium"],
+      "Commodities_combined": ["Niobium"],
+      "aliases": ["niobium", "columbium", "nb"]
+    },
+    {
+      "Major_category": "Critical minerals",
+      "Minor_category": "Tantalum",
+      "Commodities_elements": ["Tantalum"],
+      "Commodities_combined": ["Tantalum"],
+      "aliases": ["tantalum", "ta"]
+    },
+    {
+      "Major_category": "Critical minerals",
+      "Minor_category": "Chromium",
+      "Commodities_elements": ["Chromium"],
+      "Commodities_combined": ["Chromium"],
+      "aliases": ["chromium", "chromite", "cr"]
+    },
+    {
+      "Major_category": "Fertilizer minerals",
+      "Minor_category": "Potash",
+      "Commodities_elements": ["Potash"],
+      "Commodities_combined": ["Potash"],
+      "aliases": ["potash", "sylvite", "kcl"]
+    },
+    {
+      "Major_category": "Industrial minerals",
+      "Minor_category": "Fluorite",
+      "Commodities_elements": ["Fluorite"],
+      "Commodities_combined": ["Fluorspar"],
+      "aliases": ["fluorite", "fluorspar", "caf2"]
+    },
+    {
+      "Major_category": "Industrial minerals",
+      "Minor_category": "Barite",
+      "Commodities_elements": ["Barite"],
+      "Commodities_combined": ["Barite"],
+      "aliases": ["barite", "baryte", "ba"]
+    },
+    {
+      "Major_category": "Gemstones",
+      "Minor_category": "Diamonds",
+      "Commodities_elements": ["Diamond"],
+      "Commodities_combined": ["Diamonds"],
+      "aliases": ["diamond", "diamonds", "kimberlite"]
+    },
+    {
+      "Major_category": "Precious metals",
+      "Minor_category": "Gold-Silver epithermal",
+      "Commodities_elements": ["Gold", "Silver"],
+      "Commodities_combined": ["Au-Ag"],
+      "aliases": ["gold-silver", "au-ag", "ag-au", "epithermal gold"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add support for reading Rule1_OreDeposit.json so Agent0 can map commodity mentions to the requested major/minor/elements/combined format
- normalize commodity text, run multi-match detection, and update the stored Commodity (multiple) values accordingly
- provide a default Rule1_OreDeposit.json catalogue of ore deposit commodities and aliases

## Testing
- python -m py_compile agent0/agent0_perplexity.py

------
https://chatgpt.com/codex/tasks/task_e_68ca37f81c388321834e617b1337ee13